### PR TITLE
fix: add PhysicianSpeciality model into _context

### DIFF
--- a/src/Controllers/PhysicianController.cs
+++ b/src/Controllers/PhysicianController.cs
@@ -60,9 +60,14 @@ namespace TurnsBackFront.Controllers
             {
                 _context.Add(physician);
                 await _context.SaveChangesAsync();
+
                 PhysicianSpeciality physicianSpeciality = new PhysicianSpeciality();
                 physicianSpeciality.PhysicianId = physician.PhysicianId;
                 physicianSpeciality.SpecialityId = SpecialityId;
+
+                _context.Add(physicianSpeciality);
+                await _context.SaveChangesAsync();
+
                 return RedirectToAction(nameof(Index));
             }
             return View(physician);


### PR DESCRIPTION
# Description

Added PhysicianSpeciality model into TurnsContext _context. It didn't allow physician speciality to be saved in the table PhysicianSpeciality.

![image](https://github.com/Maria-RD/AppointmentScheduling/assets/50882747/ee26a164-1218-49e1-ac19-543e18f2746b)

![image](https://github.com/Maria-RD/AppointmentScheduling/assets/50882747/5c7f0b13-81ce-4c58-9a90-ce1dcec14275)

BUG-0002

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual testing.

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
